### PR TITLE
Update MobileApp endpoint

### DIFF
--- a/MobileApp/java/Configs.java
+++ b/MobileApp/java/Configs.java
@@ -70,7 +70,7 @@ public class Configs {
     public Configs() {
         this.consumer_key = "KPYMe2FTDdpk9Lo3Q0FLWPWCjwsa";
         this.consumer_secret = "ONBGvpgskS6EKutumvlTf_kh56Ua";
-        this.base_url = "https://api.princeton.edu:443/mobile-app/1.0.0";
+        this.base_url = "https://api.princeton.edu:443/mobile-app";
         this.course_courses = "/courses/courses";
         this.course_terms = "/courses/terms";
         this.dining_locations = "/dining/locations";

--- a/MobileApp/python/configs.py
+++ b/MobileApp/python/configs.py
@@ -6,7 +6,7 @@ class Configs:
     def __init__(self):
         self.CONSUMER_KEY = "KPYMe2FTDdpk9Lo3Q0FLWPWCjwsa"
         self.CONSUMER_SECRET = "ONBGvpgskS6EKutumvlTf_kh56Ua"
-        self.BASE_URL="https://api.princeton.edu:443/mobile-app/1.0.0"
+        self.BASE_URL="https://api.princeton.edu:443/mobile-app"
         self.COURSE_COURSES="/courses/courses"
         self.COURSE_TERMS="/courses/terms"
         self.DINING_LOCATIONS="/dining/locations"


### PR DESCRIPTION
The MobileApp team recently updated the API and changed the version to 1.0.2 (originally 1.0.0). This change broke TigerSnatch, a new TigerApp that relies on MobileApp. The base endpoint must now be either `https://api.princeton.edu/mobile-app/1.0.2` or `https://api.princeton.edu/mobile-app`. This PR uses the latter since it's guaranteed to be up-to-date. **See the support ticket below for more details.** Verified that the new URL works via an API request by TigerSnatch.

![image](https://user-images.githubusercontent.com/13815069/123527775-f479e600-d696-11eb-8aad-0bdbf9e7a8dc.png)
